### PR TITLE
feat: 일기 사진 선택 전체 흐름 구현

### DIFF
--- a/src/main/java/com/apply/diarypic/diary/entity/Diary.java
+++ b/src/main/java/com/apply/diarypic/diary/entity/Diary.java
@@ -1,0 +1,79 @@
+package com.apply.diarypic.diary.entity;
+
+import com.apply.diarypic.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "diaries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Diary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 일기를 작성한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 일기 제목
+    @Column(length = 255, nullable = false)
+    private String title;
+
+    // 일기 본문 (Lob으로 긴 텍스트 지원)
+    @Lob
+    private String content;
+
+    // 감정 아이콘 (예: 이모지 문자열)
+    @Column(length = 50)
+    private String emotionIcon;
+
+    // 즐겨찾기 여부 (true: 즐겨찾기, false: 일반)
+    private Boolean isFavorited;
+
+    // 상태: '확인' 또는 '미확인'
+    @Column(length = 20)
+    private String status;
+
+    // 생성 시각
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    // 수정 시각
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 논리 삭제를 위한 필드 (삭제 시점 기록, null이면 삭제되지 않은 상태)
+    private LocalDateTime deletedAt;
+
+    // DiaryPhoto와의 일대다 관계 (cascade 및 orphanRemoval 설정)
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<DiaryPhoto> diaryPhotos = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.isFavorited == null) {
+            this.isFavorited = false;
+        }
+        if (this.status == null) {
+            this.status = "미확인";
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/apply/diarypic/diary/entity/DiaryPhoto.java
+++ b/src/main/java/com/apply/diarypic/diary/entity/DiaryPhoto.java
@@ -1,0 +1,52 @@
+package com.apply.diarypic.diary.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "diary_photos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DiaryPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // S3에 저장된 사진 URL
+    @Column(nullable = false)
+    private String photoUrl;
+
+    // 촬영일 (날짜만 필요할 경우)
+    private LocalDate shootingDate;
+
+    // 촬영 장소 정보
+    private String location;
+
+    // AI 추천 사진 여부
+    private Boolean isRecommended;
+
+    // 사진의 순서 (최종 선택된 사진의 순서를 나타냄)
+    @Setter
+    private Integer sequence;
+
+    // 사진이 업로드된 시각
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    // 사진을 업로드한 사용자 ID
+    @Column(nullable = false)
+    private Long userId;
+
+    // 연관관계 설정을 위한 setter (다른 필드는 setter 없이 Builder 혹은 생성자를 사용)
+    // 해당 사진이 연결된 일기 (임시 사진은 null)
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+}

--- a/src/main/java/com/apply/diarypic/global/s3/S3Uploader.java
+++ b/src/main/java/com/apply/diarypic/global/s3/S3Uploader.java
@@ -1,17 +1,18 @@
 package com.apply.diarypic.global.s3;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
+import software.amazon.awssdk.core.sync.RequestBody;
 import java.io.IOException;
 import java.util.UUID;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class S3Uploader {
@@ -32,6 +33,22 @@ public class S3Uploader {
         s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
         return getS3Url(fileName);
+    }
+
+    public void delete(String fileUrl) {
+        // fileUrl 예: https://{bucket}.s3.ap-northeast-2.amazonaws.com/{fileName}
+        String prefix = String.format("https://%s.s3.ap-northeast-2.amazonaws.com/", bucket);
+        if (!fileUrl.startsWith(prefix)) {
+            log.error("파일 URL 형식이 올바르지 않습니다: {}", fileUrl);
+            throw new IllegalArgumentException("파일 URL 형식이 올바르지 않습니다.");
+        }
+        String key = fileUrl.replace(prefix, "");
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        s3Client.deleteObject(deleteRequest);
+        log.info("S3에서 파일 삭제: key={}", key);
     }
 
     private String getS3Url(String fileName) {

--- a/src/main/java/com/apply/diarypic/photo/controller/PhotoController.java
+++ b/src/main/java/com/apply/diarypic/photo/controller/PhotoController.java
@@ -1,5 +1,7 @@
 package com.apply.diarypic.photo.controller;
 
+import com.apply.diarypic.global.security.CurrentUser;
+import com.apply.diarypic.global.security.UserPrincipal;
 import com.apply.diarypic.photo.service.PhotoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,14 +23,14 @@ public class PhotoController {
 
     private final PhotoService photoService;
 
-    @Operation(summary = "사진 여러 장 업로드 (S3)")
+    @Operation(summary = "사진 여러 장 업로드 (S3 및 DB 임시 저장)")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<List<String>> uploadPhotos(
+            @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "업로드할 이미지 파일들", content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE))
             @RequestPart("files") List<MultipartFile> files) {
 
-        List<String> uploadedUrls = photoService.uploadAll(files);
+        List<String> uploadedUrls = photoService.uploadAll(files, userPrincipal.getUserId());
         return ResponseEntity.ok(uploadedUrls);
     }
-
 }

--- a/src/main/java/com/apply/diarypic/photo/controller/PhotoSelectionController.java
+++ b/src/main/java/com/apply/diarypic/photo/controller/PhotoSelectionController.java
@@ -1,0 +1,45 @@
+package com.apply.diarypic.photo.controller;
+
+import com.apply.diarypic.diary.entity.DiaryPhoto;
+import com.apply.diarypic.global.security.CurrentUser;
+import com.apply.diarypic.global.security.UserPrincipal;
+import com.apply.diarypic.photo.dto.FinalizePhotoSelectionRequest;
+import com.apply.diarypic.photo.service.PhotoSelectionService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/photos/selection")
+@RequiredArgsConstructor
+public class PhotoSelectionController {
+
+    private final PhotoSelectionService photoSelectionService;
+
+    @Operation(summary = "임시 업로드 사진 조회")
+    @GetMapping("/temp")
+    public ResponseEntity<List<DiaryPhoto>> getTemporaryPhotos(@CurrentUser UserPrincipal userPrincipal) {
+        List<DiaryPhoto> tempPhotos = photoSelectionService.getTemporaryPhotos(userPrincipal.getUserId());
+        return ResponseEntity.ok(tempPhotos);
+    }
+
+    @Operation(summary = "최종 사진 선택 확정 (최종 10장 구성)")
+    @PostMapping("/finalize")
+    public ResponseEntity<List<DiaryPhoto>> finalizePhotoSelection(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Valid @RequestBody FinalizePhotoSelectionRequest request) {
+        List<DiaryPhoto> finalPhotos = photoSelectionService.finalizePhotoSelection(userPrincipal.getUserId(), request.getPhotoIds());
+        return ResponseEntity.ok(finalPhotos);
+    }
+
+    @Operation(summary = "임시 사진 개별 삭제")
+    @DeleteMapping("/{photoId}")
+    public ResponseEntity<Void> deletePhoto(@CurrentUser UserPrincipal userPrincipal,
+                                            @PathVariable Long photoId) {
+        photoSelectionService.deletePhoto(userPrincipal.getUserId(), photoId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/apply/diarypic/photo/dto/FinalizePhotoSelectionRequest.java
+++ b/src/main/java/com/apply/diarypic/photo/dto/FinalizePhotoSelectionRequest.java
@@ -1,0 +1,11 @@
+package com.apply.diarypic.photo.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class FinalizePhotoSelectionRequest {
+    @NotEmpty(message = "최종 선택할 사진 ID 목록이 비어있을 수 없습니다.")
+    private List<Long> photoIds;
+}

--- a/src/main/java/com/apply/diarypic/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/apply/diarypic/photo/repository/PhotoRepository.java
@@ -1,0 +1,9 @@
+package com.apply.diarypic.photo.repository;
+
+import com.apply.diarypic.diary.entity.DiaryPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface PhotoRepository extends JpaRepository<DiaryPhoto, Long> {
+    List<DiaryPhoto> findByDiaryIsNullAndUserId(Long userId);
+}

--- a/src/main/java/com/apply/diarypic/photo/service/PhotoSelectionService.java
+++ b/src/main/java/com/apply/diarypic/photo/service/PhotoSelectionService.java
@@ -1,0 +1,114 @@
+package com.apply.diarypic.photo.service;
+
+import com.apply.diarypic.diary.entity.DiaryPhoto;
+import com.apply.diarypic.global.s3.S3Uploader;
+import com.apply.diarypic.photo.repository.PhotoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoSelectionService {
+
+    private final PhotoRepository photoRepository;
+    private final S3Uploader s3Uploader; // S3 파일 삭제 기능 포함
+
+    /**
+     * 현재 사용자의 임시 업로드 사진 조회 (diary가 아직 연결되지 않은 사진)
+     */
+    @Transactional(readOnly = true)
+    public List<DiaryPhoto> getTemporaryPhotos(Long userId) {
+        return photoRepository.findByDiaryIsNullAndUserId(userId);
+    }
+
+    /**
+     * 최종 선택 확정
+     * - 사용자가 선택한 사진 ID 목록(순서대로)을 기반으로 최종 목록을 구성
+     * - 최종 선택에 포함되지 않은 사진은 S3와 DB에서 삭제
+     * - 최종 선택 사진에는 순서(sequence)를 업데이트
+     *
+     * @param userId       현재 사용자 ID
+     * @param finalPhotoIds 최종 선택된 사진 ID 목록
+     * @return 최종 선택된 사진 목록
+     */
+    @Transactional
+    public List<DiaryPhoto> finalizePhotoSelection(Long userId, List<Long> finalPhotoIds) {
+        // 현재 사용자의 임시 사진 조회
+        List<DiaryPhoto> tempPhotos = photoRepository.findByDiaryIsNullAndUserId(userId);
+        if (tempPhotos.isEmpty()) {
+            throw new IllegalArgumentException("임시 업로드된 사진이 없습니다.");
+        }
+
+        // 최종 선택 사진 필터링
+        List<DiaryPhoto> finalPhotos = tempPhotos.stream()
+                .filter(photo -> finalPhotoIds.contains(photo.getId()))
+                .collect(Collectors.toList());
+
+        if (finalPhotos.size() > 10) {
+            throw new IllegalArgumentException("최종 선택 사진은 최대 10장까지 가능합니다.");
+        }
+
+        // 최종 선택에 포함되지 않은 사진은 삭제 대상
+        List<DiaryPhoto> photosToDelete = tempPhotos.stream()
+                .filter(photo -> !finalPhotoIds.contains(photo.getId()))
+                .collect(Collectors.toList());
+
+        // 최종 사진 순서 업데이트 (리스트 순서대로 sequence 값 지정)
+        for (int i = 0; i < finalPhotoIds.size(); i++) {
+            Long photoId = finalPhotoIds.get(i);
+            for (DiaryPhoto photo : finalPhotos) {
+                if (photo.getId().equals(photoId)) {
+                    photo.setSequence(i + 1); // sequence 1부터 시작
+                    break;
+                }
+            }
+        }
+
+        // 최종 선택에 포함되지 않은 사진 S3 및 DB 삭제
+        for (DiaryPhoto photo : photosToDelete) {
+            try {
+                s3Uploader.delete(photo.getPhotoUrl());
+                log.info("S3에서 사진 삭제 성공: {}", photo.getPhotoUrl());
+            } catch (Exception e) {
+                log.error("S3 사진 삭제 실패: {}", photo.getPhotoUrl(), e);
+            }
+            photoRepository.delete(photo);
+            log.info("DB에서 사진 삭제 성공: ID {}", photo.getId());
+        }
+
+        return finalPhotos;
+    }
+
+    /**
+     * 임시 사진 개별 삭제
+     *
+     * @param userId  현재 사용자 ID
+     * @param photoId 삭제할 사진 ID
+     */
+    @Transactional
+    public void deletePhoto(Long userId, Long photoId) {
+        DiaryPhoto photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사진이 존재하지 않습니다."));
+        if (photo.getDiary() != null) {
+            throw new IllegalArgumentException("이미 일기에 등록된 사진은 삭제할 수 없습니다.");
+        }
+        if (!photo.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("해당 사진에 대한 삭제 권한이 없습니다.");
+        }
+        try {
+            s3Uploader.delete(photo.getPhotoUrl());
+            log.info("S3에서 사진 삭제 성공: {}", photo.getPhotoUrl());
+        } catch (Exception e) {
+            log.error("S3 사진 삭제 실패: {}", photo.getPhotoUrl(), e);
+            throw new RuntimeException("사진 삭제 중 오류가 발생했습니다.");
+        }
+        photoRepository.delete(photo);
+        log.info("DB에서 사진 삭제 성공: ID {}", photoId);
+    }
+}

--- a/src/main/java/com/apply/diarypic/photo/service/PhotoService.java
+++ b/src/main/java/com/apply/diarypic/photo/service/PhotoService.java
@@ -1,11 +1,14 @@
 package com.apply.diarypic.photo.service;
 
+import com.apply.diarypic.diary.entity.DiaryPhoto;
 import com.apply.diarypic.global.s3.S3Uploader;
+import com.apply.diarypic.photo.repository.PhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,20 +17,28 @@ import java.util.stream.Collectors;
 public class PhotoService {
 
     private final S3Uploader s3Uploader;
+    private final PhotoRepository photoRepository;
 
-    public String upload(MultipartFile file) {
+    public String upload(MultipartFile file, Long userId) {
         try {
-            return s3Uploader.upload(file, "photos");
+            String url = s3Uploader.upload(file, "photos");
+            // 임시 저장용 DiaryPhoto 엔티티 생성 (diary 연결은 아직 하지 않음)
+            DiaryPhoto diaryPhoto = DiaryPhoto.builder()
+                    .photoUrl(url)
+                    .userId(userId)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            photoRepository.save(diaryPhoto);
+            return url;
         } catch (IOException e) {
             throw new RuntimeException("파일 업로드 실패", e);
         }
     }
 
-    public List<String> uploadAll(List<MultipartFile> files) {
-        // 기존 단일 업로드 재사용
+    public List<String> uploadAll(List<MultipartFile> files, Long userId) {
+        // 단일 업로드 재사용 후 URL 목록 반환
         return files.stream()
-                .map(this::upload)
+                .map(file -> upload(file, userId))
                 .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
- 여러장 사진 업로드 기능 구현 (S3 저장 및 diary_photos 테이블에 임시 저장)
- 필수 포함 사진 선택 기능 추가
- 선택되지 않은 사진 자동 삭제 로직 구현
- 일기 본문 작성 페이지에서 사진 추가/삭제/순서 조정(드래그 앤 드롭) 기능 구현